### PR TITLE
BcolzArrayIterator slight changes

### DIFF
--- a/bcolz_array_iterator.py
+++ b/bcolz_array_iterator.py
@@ -29,6 +29,7 @@ class BcolzArrayIterator(object):
         >>> C = np.concatenate(C_list)
         >>> np.allclose(sorted(A.flatten()), sorted(C.flatten()))
         True
+        >>> c.purge()
     """
 
     def __init__(self, X, y=None, w=None, batch_size=32, shuffle=False, seed=None):

--- a/bcolz_array_iterator.py
+++ b/bcolz_array_iterator.py
@@ -63,8 +63,8 @@ class BcolzArrayIterator(object):
             if self.batch_index == 0:
                 if self.seed is not None:
                     np.random.seed(self.seed + self.total_batches_seen)
-                self.index_array = (np.random.permutation(self.X.nchunks + 1) if self.shuffle
-                    else np.arange(self.X.nchunks + 1))
+                index_length = (self.X.nchunks + 1) if self.X.leftover_elements > 0 else self.X.nchunks
+                self.index_array = (np.random.permutation(index_length) if self.shuffle else np.arange(index_length))
 
             #batches_x = np.zeros((self.batch_size,)+self.X.shape[1:])
             batches_x, batches_y, batches_w = [],[],[]

--- a/bcolz_array_iterator.py
+++ b/bcolz_array_iterator.py
@@ -53,20 +53,21 @@ class BcolzArrayIterator(object):
         self.lock = threading.Lock()
         self.shuffle = shuffle
         self.seed = seed
+        self.loop()
 
 
     def reset(self): self.batch_index = 0
 
+    def loop(self):
+        self.batch_index = 0
+        if self.seed is not None:
+            np.random.seed(self.seed + self.total_batches_seen)
+        index_length = (self.X.nchunks + 1) if self.X.leftover_elements > 0 else self.X.nchunks
+        self.index_array = (np.random.permutation(index_length) if self.shuffle else np.arange(index_length))
+
 
     def next(self):
         with self.lock:
-            if self.batch_index == 0:
-                if self.seed is not None:
-                    np.random.seed(self.seed + self.total_batches_seen)
-                index_length = (self.X.nchunks + 1) if self.X.leftover_elements > 0 else self.X.nchunks
-                self.index_array = (np.random.permutation(index_length) if self.shuffle else np.arange(index_length))
-
-            #batches_x = np.zeros((self.batch_size,)+self.X.shape[1:])
             batches_x, batches_y, batches_w = [],[],[]
             for i in range(self.chunks_per_batch):
                 current_index = self.index_array[self.batch_index]
@@ -83,7 +84,7 @@ class BcolzArrayIterator(object):
                 if not self.y is None: batches_y.append(self.y[idx: idx + current_batch_size])
                 if not self.w is None: batches_w.append(self.w[idx: idx + current_batch_size])
                 if self.batch_index >= len(self.index_array):
-                    self.batch_index = 0
+                    self.loop()
                     break
 
             batch_x = np.concatenate(batches_x)


### PR DESCRIPTION
I did some testing with a version of the iterator with pre-allocation of the np arrays.

However this turned out to be slightly slower than the current approach, using line_profiler showed that actually contatenating the list is only 3.4% of the time spent, the logic needed to pre-allocate the array is more expensive and assigneing to slices of numpy arrays is actually slower than appending to a list.

The changes avoid leaving a file after running the doctest by purging the carray and avoid checking for index==0 at the beginning of each loop, shaving a few percent off execution time. 
Finally the case where the chunk_lenght and data_size match up (leaving no leftover_data) would return an empty array, is solved.

