### PR TITLE
Removed unused imports that were causing errors.

### DIFF
--- a/utils2.py
+++ b/utils2.py
@@ -11,7 +11,7 @@ from IPython.display import display, Audio
 from numpy.random import normal
 from gensim.models import word2vec
 from keras.preprocessing.text import Tokenizer
-from nltk.tokenize import ToktokTokenizer, StanfordTokenizer
+from nltk.tokenize import ToktokTokenizer
 from functools import reduce
 from itertools import chain
 
@@ -19,7 +19,6 @@ from tensorflow.python.framework import ops
 #from tensorflow.contrib import rnn, legacy_seq2seq as seq2seq
 
 from keras_tqdm import TQDMNotebookCallback
-from keras import initializations
 from keras.applications.resnet50 import ResNet50, decode_predictions, conv_block, identity_block
 from keras.applications.vgg16 import VGG16
 from keras.preprocessing import image


### PR DESCRIPTION
I ran into these errors while trying to run `DCGAN.ipynb` (almost certainly due to different versions of Keras and nltk). Since these particular imports are unused, there is no reason to keep them.

```
~/workspace/part2/utils2.py in <module>()
     12 from gensim.models import word2vec
     13 from keras.preprocessing.text import Tokenizer
---> 14 from nltk.tokenize import ToktokTokenizer, StanfordTokenizer
     15 from functools import reduce
     16 from itertools import chain

ImportError: cannot import name 'StanfordTokenizer'
```

```
~/workspace/part2/utils2.py in <module>()
     20 
     21 from keras_tqdm import TQDMNotebookCallback
---> 22 from keras import initializations
     23 from keras.applications.resnet50 import ResNet50, decode_predictions, conv_block, identity_block
     24 from keras.applications.vgg16 import VGG16

ImportError: cannot import name 'initializations'
```

Note that many other imports in utils appear unused, but I've left them untouched (wanted to keep changes to a minimum).

## Test Plan
- Verify using PyCharm and grep that the imports are unused.
- After other fixes, successfully run `DCGAN.ipynb`.