### PR TITLE
Fix missing variable 'm', which should be 'MLP_m'.

### DIFF
--- a/DCGAN.ipynb
+++ b/DCGAN.ipynb
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "dl,gl = train(MLP_D, MLP_G, m, 4000)"
+    "dl,gl = train(MLP_D, MLP_G, MLP_m, 4000)"
    ]
   },
   {


### PR DESCRIPTION
```
NameError                                 Traceback (most recent call last)
<ipython-input-43-c13c6882f074> in <module>()
----> 1 dl,gl = train(MLP_D, MLP_G, m, 4000)

NameError: name 'm' is not defined
```

This is clearly intended to be `MLP_m `.

## Test Plan
- After making this change, this part of the notebook works.
